### PR TITLE
Added back to top smooth scroll button

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -197,6 +197,11 @@ export default function Index() {
               }
             </div>
       }
+      <div className={styles.footer_buttons}>
+        <button onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}>
+          ⬆️
+        </button>
+      </div>
     </div>
   );
 }

--- a/styles/pages/Index.module.scss
+++ b/styles/pages/Index.module.scss
@@ -38,6 +38,29 @@
     }
   }
 
+  >.footer_buttons{
+    position: absolute;
+    bottom: 10px;
+    margin-top: 30px;
+    left: 50%;
+    transform: translateX(-50%);
+    display: flex;
+    gap: 16px;
+    
+    >button {
+      width: 48px;
+      height: 48px;
+      padding: 0;
+      background: transparent;
+      font-size: 48px;
+      border: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding-top: 3px;
+    }
+  }
+
   >.filters {
     display: flex;
     align-items: center;


### PR DESCRIPTION
Added a bottom at bottom of page to scroll back to the top + styling for footer buttons.

Useful now and even more useful when more items get added.


https://github.com/csaye/interning.dev/assets/97154067/37838737-e0c7-4afb-9bec-4bb73df98dbf

